### PR TITLE
Update workflow script to pass cypress-based e2e testing

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -15,7 +15,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -32,4 +32,4 @@ jobs:
       with:
         start: yarn dev
         wait-on: 'http://localhost:8000'
-        wait-on-timeout: 120
+        wait-on-timeout: 400

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -32,3 +32,4 @@ jobs:
       with:
         start: yarn dev
         wait-on: 'http://localhost:8000'
+        wait-on-timeout: 120

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -25,6 +25,10 @@ jobs:
     # Runs a set of commands using the runners shell
     - name: Run a multi-line script
       run: |
-        npm install
-        yarn dev
-        yarn test
+        echo Add other actions to build,
+        echo test, and deploy your project.
+    - name: Cypress.io
+      uses: cypress-io/github-action@v1.16.1
+      with:
+        start: yarn dev
+        wait-on: 'http://localhost:8000'

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -6,7 +6,7 @@ name: CI
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
     branches: [ master ]
 
@@ -34,7 +34,5 @@ jobs:
     - name: Cypress.io
       uses: cypress-io/github-action@v1.16.1
       with:
-        working-directory: /
-        build: yarn run build
         start: yarn dev
         wait-on: 'http://localhost:8000'

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -25,5 +25,6 @@ jobs:
     # Runs a set of commands using the runners shell
     - name: Run a multi-line script
       run: |
+        npm install
         yarn dev
         yarn test

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -22,17 +22,8 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    # Runs a single command using the runners shell
-    - name: Run a one-line script
-      run: echo Hello, world!
-
     # Runs a set of commands using the runners shell
     - name: Run a multi-line script
       run: |
-        echo Add other actions to build,
-        echo test, and deploy your project.
-    - name: Cypress.io
-      uses: cypress-io/github-action@v1.16.1
-      with:
-        start: yarn dev
-        wait-on: 'http://localhost:8000'
+        yarn dev
+        yarn test


### PR DESCRIPTION
Set `wait-on-timeout` as `240` to wait the Gatsby app.